### PR TITLE
feat(start/reset): Added functionality to start the game and reset

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -20,8 +20,15 @@ function draw() {
   paddle2.create();
   ballInit.create();
 
-  //function call for moving paddles
-  paddleMove();
+  //check to see if gameState is true
+  if(gameState){
+    //function call for moving paddles
+    paddleMove();
+  }
+  else{
+
+  }
+
 }
 
 //function that moves the paddle when key is down
@@ -41,5 +48,21 @@ function paddleMove(){
   //ascii 75 is K
   else if (keyIsDown(75)) {
     paddle2.move(5);
+  }
+}
+
+function keyPressed(){
+  //when spacebar is pressed game starts
+  if(key === ' '){
+    gameState = true;
+  }
+  //this should reset the game to initial conditions
+  else if(key === 'r'){
+    //change back gameState
+    gameState = false;
+    //call reset for paddles and ball
+    paddle1.reset();
+    paddle2.reset();
+    ball.reset();
   }
 }


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added gameState to declare when game is starting and when it is not
2. Added reset functionality so paddles stop moving when reset

## Purpose
_Describe the problem or feature._
User can now start the game and cant do anything until game starts
## Approach
_How does this change address the problem?_
Game doesnt automatically start upon load
## Learning
_Describe the research stage_
Learned about keyPressed
_Links to blog posts, patterns, libraries or addons used to solve this problem_
[keyPressed](https://p5js.org/reference/#/p5/keyPressed)
_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #6 
