### PR TITLE
16 start screen

### DIFF
--- a/js/sketch.js
+++ b/js/sketch.js
@@ -12,6 +12,15 @@ function setup() {
   ballInit = new Ball(width/2,height/2,10,10);
 }
 
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
+  
+  paddle1 = new Paddle(30,height/2-50,10,100);
+  paddle2 = new Paddle(width-30,height/2-50,10,100);
+  ballInit = new Ball(width/2,height/2,10,10);
+}
+
+
 //p5.js draw function constantly runs
 function draw() {
   background(150);
@@ -26,7 +35,8 @@ function draw() {
     paddleMove();
   }
   else{
-
+    //function runs when game not started
+    startScreen();
   }
 
 }
@@ -65,4 +75,8 @@ function keyPressed(){
     paddle2.reset();
     ball.reset();
   }
+}
+
+function startScreen(){
+
 }

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -14,7 +14,7 @@ function setup() {
 
 function windowResized() {
   resizeCanvas(windowWidth, windowHeight);
-  
+
   paddle1 = new Paddle(30,height/2-50,10,100);
   paddle2 = new Paddle(width-30,height/2-50,10,100);
   ballInit = new Ball(width/2,height/2,10,10);
@@ -78,5 +78,10 @@ function keyPressed(){
 }
 
 function startScreen(){
-
+  noStroke();
+  fill(255);
+  textSize(50);
+  textAlign(CENTER);
+  text('Start Game:', width/2, 100);
+  text('Spacebar', width/2, height-100);
 }


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Added start screen on load.
2. Added Canvas resize when window screen is resized.

## Purpose
Allows user to resize screen and canvas follows suit. As well as allow user to view the start screen and know how to begin the game.

## Approach
Allows user to visually see the start of the game.

## Learning
_Describe the research stage_
Learned about p5.js text, windowResized and resizeCanvas.
_Links to blog posts, patterns, libraries or addons used to solve this problem_
[textAlign](https://p5js.org/reference/#/p5/textAlign)
[text](https://p5js.org/reference/#/p5/text)
[windowResize](https://p5js.org/reference/#/p5/windowResized)
[resizeCanvas](https://p5js.org/reference/#/p5/resizeCanvas)
_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #16 
